### PR TITLE
Py linted config py

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,7 @@
+""" This is a config files used by gunicorn """
+# Disabling the pylint message about the 'forward_allowed_ips' even
+# as this is a constanst defined by gunicorn.
+# pylint: disable=C0103
 import os
 
 workers = int(os.environ.get("GUNICORN_PROCESSES", "3"))


### PR DESCRIPTION
This just lints the config.py file that is used by gunicorn.

- disabled the lint message about the naming convention of the constant as we don't have control over that
- added a doc string to the top of the file.