### PR TITLE
Correct pylint warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[FORMAT]
+max-line-length=160
+
+[MESSAGES CONTROL]
+disable = missing-function-docstring,fixme,unspecified-encoding

--- a/moc_openshift.py
+++ b/moc_openshift.py
@@ -1,3 +1,5 @@
+"""API wrapper for interacting with OpenShift authorization"""
+
 import abc
 import pprint
 import json
@@ -7,6 +9,8 @@ from flask import Response
 
 
 class MocOpenShift(metaclass=abc.ABCMeta):
+    """API wrapper interface"""
+
     headers = None
     verify = False
     url = None
@@ -45,6 +49,7 @@ class MocOpenShift(metaclass=abc.ABCMeta):
     def get_url(self):
         return self.url
 
+    # pylint: disable=no-self-use
     def cnvt_project_name(self, project_name):
         suggested_project_name = re.sub("^[^A-Za-z0-9]+", "", project_name)
         suggested_project_name = re.sub("[^A-Za-z0-9]+$", "", suggested_project_name)
@@ -84,7 +89,7 @@ class MocOpenShift(metaclass=abc.ABCMeta):
                 url, headers=self.headers, data=json.dumps(payload), verify=self.verify
             )
         if debug:
-            self.logger.info(f"url: " + url)
+            self.logger.info(f"url: {url}")
             if payload is not None:
                 self.logger.info(f"payload: {json.dumps(payload)}")
             self.logger.info(f"pu: {str(result.status_code)}")
@@ -104,17 +109,14 @@ class MocOpenShift(metaclass=abc.ABCMeta):
 
     def user_exists(self, user_name):
         result = self.get_user(user_name)
-        if result.status_code == 200 or result.status_code == 201:
+        if result.status_code in (200, 201):
             return True
         return False
 
     def useridentitymapping_exists(self, user_name, id_provider, id_user):
         user = self.get_user(user_name)
-        if (
-            not (user.status_code == 200 or user.status_code == 201)
-            and user["identities"]
-        ):
-            id_str = "{}:{}".format(id_provider, id_user)
+        if not (user.status_code in (200, 201)) and user["identities"]:
+            id_str = f"{id_provider}:{id_user}"
             for identity in user["identities"]:
                 if identity == id_str:
                     return True
@@ -133,7 +135,7 @@ class MocOpenShift(metaclass=abc.ABCMeta):
             return False
 
         result = self.get_rolebindings(project_name, openshift_role)
-        if result.status_code == 200 or result.status_code == 201:
+        if result.status_code in (200, 201):
             role_binding = result.json()
             pprint.pprint(role_binding)
             if (
@@ -163,7 +165,9 @@ class MocOpenShift(metaclass=abc.ABCMeta):
             mimetype="application/json",
         )
 
-    def update_user_role_project(self, project_name, user, role, operation):
+    def update_user_role_project(
+        self, project_name, user, role, operation
+    ):  # pylint: disable=too-many-return-statements,too-many-branches
         # The REST API 'create rolebindings' doesn't work the way that 'oc create rolebindings'
         # with the REST API,
         #     GET can be used to get the specific role from the project (or all roles)
@@ -200,12 +204,12 @@ class MocOpenShift(metaclass=abc.ABCMeta):
             )
 
         result = self.get_rolebindings(project_name, openshift_role)
-        if not (result.status_code == 200 or result.status_code == 201):
+        if result.status_code not in (200, 201):
             if operation == "add":
                 # try to create the roles for binding
                 self.logger.info("Creating role bindings")
                 result = self.create_rolebindings(project_name, user, openshift_role)
-                if result.status_code == 200 or result.status_code == 201:
+                if result.status_code in (200, 201):
                     return Response(
                         response=json.dumps(
                             {
@@ -224,7 +228,8 @@ class MocOpenShift(metaclass=abc.ABCMeta):
                     status=400,
                     mimetype="application/json",
                 )
-            elif operation == "del":
+
+            if operation == "del":
                 # this is done for purely defensive reasons, shouldn't happen due to our current business
                 self.logger.info(
                     "Warning: Attempt to delete from an newly created project - has the business logic changed"
@@ -238,18 +243,18 @@ class MocOpenShift(metaclass=abc.ABCMeta):
                     status=400,
                     mimetype="application/json",
                 )
-            else:
-                # should never get here, but also done for purely defensive reasons
-                self.logger.info("Error: unknown create operation")
-                return Response(
-                    response=json.dumps(
-                        {"msg": f"invalid request ({user},{project_name},{role})"}
-                    ),
-                    status=400,
-                    mimetype="application/json",
-                )
 
-        if result.status_code == 200 or result.status_code == 201:
+            # should never get here, but also done for purely defensive reasons
+            self.logger.info("Error: unknown create operation")
+            return Response(
+                response=json.dumps(
+                    {"msg": f"invalid request ({user},{project_name},{role})"}
+                ),
+                status=400,
+                mimetype="application/json",
+            )
+
+        if result.status_code in (200, 201):
             role_binding = result.json()
             if operation == "add":
                 self.logger.debug("role_binding: " + json.dumps(role_binding))
@@ -302,7 +307,7 @@ class MocOpenShift(metaclass=abc.ABCMeta):
             )
 
             msg = "unknown message"
-            if result.status_code == 200 or result.status_code == 201:
+            if result.status_code in (200, 201):
                 if operation == "add":
                     msg = "Added role to user on project"
                 elif operation == "del":
@@ -331,12 +336,13 @@ class MocOpenShift(metaclass=abc.ABCMeta):
 
 
 class MocOpenShift4x(MocOpenShift):
+    """API implementation for OpenShift 4.x"""
 
     # member functions for projects
     def project_exists(self, project_name):
         url = f"{self.get_url()}/apis/project.openshift.io/v1/projects/{project_name}"
         result = self.get_request(url, True)
-        if result.status_code == 200 or result.status_code == 201:
+        if result.status_code in (200, 201):
             return True
         return False
 
@@ -384,7 +390,7 @@ class MocOpenShift4x(MocOpenShift):
     def identity_exists(self, id_provider, id_user):
         url = f"{self.get_url()}/apis/user.openshift.io/v1/identities/{id_provider}:{id_user}"
         result = self.get_request(url, True)
-        if result.status_code == 200 or result.status_code == 201:
+        if result.status_code in (200, 201):
             return True
         return False
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -51,6 +51,12 @@ def get_openshift():
 
 @AUTH.verify_password
 def verify_password(username, password):
+    """Validates a username and password.
+
+    WARNING: This function always succeeds (anybody can log in) if the auth
+    file is missing.
+    """
+
     try:
         with open("/app/auth/users", "r") as my_file:
             user_str = my_file.read()
@@ -60,6 +66,8 @@ def verify_password(username, password):
                 return username
     except FileNotFoundError:
         return True
+
+    return False
 
 
 @APP.route("/users/<user_name>/projects/<project_name>/roles/<role>", methods=["GET"])

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,3 +1,5 @@
+"""WSGI application for MOC openshift account management microservice"""
+
 import logging
 import json
 import os
@@ -15,7 +17,12 @@ if __name__ != "__main__":
 
 
 class MocOpenShiftSingleton:
-    class __MocOSInt:
+    """Ensure a single instance of the OpenShift API"""
+
+    # pylint: disable=too-few-public-methods
+    class MocOSInt:
+        """Wrapper for API openshift API class"""
+
         def __init__(self, version, url, logger):
             with open(
                 "/var/run/secrets/kubernetes.io/serviceaccount/token", "r"
@@ -32,7 +39,7 @@ class MocOpenShiftSingleton:
 
     def __init__(self, version, url, logger):
         if not MocOpenShiftSingleton.openshift_instance:
-            MocOpenShiftSingleton.openshift_instance = MocOpenShiftSingleton.__MocOSInt(
+            MocOpenShiftSingleton.openshift_instance = MocOpenShiftSingleton.MocOSInt(
                 version, url, logger
             )
 
@@ -88,7 +95,7 @@ def create_moc_rolebindings(project_name, user_name, role):
     # role can be one of Admin, Member, Reader
     shift = get_openshift()
     result = shift.update_user_role_project(project_name, user_name, role, "add")
-    if result.status_code == 200 or result.status_code == 201:
+    if result.status_code in (200, 201):
         return Response(
             response=result.response,
             status=200,
@@ -109,7 +116,7 @@ def delete_moc_rolebindings(project_name, user_name, role):
     # role can be one of Admin, Member, Reader
     shift = get_openshift()
     result = shift.update_user_role_project(project_name, user_name, role, "del")
-    if result.status_code == 200 or result.status_code == 201:
+    if result.status_code in (200, 201):
         return Response(
             response=result.response,
             status=200,
@@ -165,12 +172,12 @@ def create_moc_project(project_uuid, user_name=None):
             req_json = request.get_json(force=True)
             if "displayName" in req_json:
                 project_name = req_json["displayName"]
-            APP.logger.debug("create project json: " + project_name)
+            APP.logger.debug("create project json: %s", project_name)
         else:
             APP.logger.debug("create project json: None")
 
         result = shift.create_project(project_uuid, project_name, user_name)
-        if result.status_code == 200 or result.status_code == 201:
+        if result.status_code in (200, 201):
             return Response(
                 response=json.dumps({"msg": f"project created ({project_uuid})"}),
                 status=200,
@@ -196,7 +203,7 @@ def delete_moc_project(project_uuid):
     shift = get_openshift()
     if shift.project_exists(project_uuid):
         result = shift.delete_project(project_uuid)
-        if result.status_code == 200 or result.status_code == 201:
+        if result.status_code in (200, 201):
             return Response(
                 response=json.dumps({"msg": f"project deleted ({project_uuid})"}),
                 status=200,
@@ -241,7 +248,9 @@ def create_moc_user(user_name):
     # these three values should be added to generalize this function
     # full_name    - the full name of the user as it is really convenient to confirm who the account belongs to
     # id_provider  - the id provider (was sso_auth, now is moc-sso)
-    # id_user      - the user name associated with the id provider.  can be used to map muliple sso users to a an account as people don't always remember which sso account they are logged in as
+    # id_user      - the user name associated with the id provider.  can be used
+    #                to map muliple sso users to a an account as people don't always
+    #                remember which sso account they are logged in as
     # id_provider = "moc-sso"
     id_provider = "developer"
     full_name = user_name
@@ -252,10 +261,10 @@ def create_moc_user(user_name):
     # use case if User doesn't exist, then create
     if not shift.user_exists(user_name):
         result = shift.create_user(user_name, full_name)
-        if result.status_code != 200 and result.status_code != 201:
+        if result.status_code not in (200, 201):
             return Response(
                 response=json.dumps(
-                    {f"msg": "unable to create openshift user ({user_name}) 1"}
+                    {"msg": f"unable to create openshift user ({user_name}) 1"}
                 ),
                 status=400,
                 mimetype="application/json",
@@ -267,7 +276,7 @@ def create_moc_user(user_name):
     # if identity doesn't exist then create
     if not shift.identity_exists(id_provider, id_user):
         result = shift.create_identity(id_provider, id_user)
-        if result.status_code != 200 and result.status_code != 201:
+        if result.status_code not in (200, 201):
             return Response(
                 response=json.dumps(
                     {"msg": f"unable to create openshift identity ({id_provider})"}
@@ -282,7 +291,7 @@ def create_moc_user(user_name):
     user_identity_mapping_exists = False
     if not shift.useridentitymapping_exists(user_name, id_provider, id_user):
         result = shift.create_useridentitymapping(user_name, id_provider, id_user)
-        if result.status_code != 200 and result.status_code != 201:
+        if result.status_code not in (200, 201):
             return Response(
                 response=json.dumps(
                     {
@@ -316,7 +325,7 @@ def delete_moc_user(user_name):
     # use case if User exists then delete
     if shift.user_exists(user_name):
         result = shift.delete_user(user_name)
-        if result.status_code != 200 and result.status_code != 201:
+        if result.status_code not in (200, 201):
             return Response(
                 response=json.dumps({"msg": f"unable to delete User ({user_name}) 1"}),
                 status=400,
@@ -334,7 +343,7 @@ def delete_moc_user(user_name):
 
     if shift.identity_exists(id_provider, id_user):
         result = shift.delete_identity(id_provider, id_user)
-        if result.status_code != 200 and result.status_code != 201:
+        if result.status_code not in (200, 201):
             return Response(
                 response=json.dumps(
                     {"msg": f"unable to delete identity ({id_provider})"}

--- a/wsgi.py
+++ b/wsgi.py
@@ -23,24 +23,20 @@ class MocOpenShiftSingleton:
     class MocOSInt:
         """Wrapper for API openshift API class"""
 
-        def __init__(self, version, url, logger):
+        def __init__(self, url, logger):
             with open(
                 "/var/run/secrets/kubernetes.io/serviceaccount/token", "r"
             ) as file:
                 token = file.read()
-                # if version == "3":
-                #    self.shift = moc_openshift.MocOpenShift3x(url, token, logger)
-                #    APP.logger.info("using Openshift ver 3")
-                # else:
                 self.shift = moc_openshift.MocOpenShift4x(url, token, logger)
                 APP.logger.info("using Openshift ver 4")
 
     openshift_instance = None
 
-    def __init__(self, version, url, logger):
+    def __init__(self, url, logger):
         if not MocOpenShiftSingleton.openshift_instance:
             MocOpenShiftSingleton.openshift_instance = MocOpenShiftSingleton.MocOSInt(
-                version, url, logger
+                url, logger
             )
 
     def get_openshift(self):
@@ -48,9 +44,8 @@ class MocOpenShiftSingleton:
 
 
 def get_openshift():
-    version = os.environ["OPENSHIFT_VERSION"]
     url = os.environ["OPENSHIFT_URL"]
-    shift = MocOpenShiftSingleton(version, url, APP.logger).get_openshift()
+    shift = MocOpenShiftSingleton(url, APP.logger).get_openshift()
     return shift
 
 


### PR DESCRIPTION
This series of commits resolves (or disables) the following pylint warnings in `moc_openshift.py`:

```
************* Module moc_openshift
moc_openshift.py:195:0: C0301: Line too long (105/100) (line-too-long)
moc_openshift.py:221:0: C0301: Line too long (110/100) (line-too-long)
moc_openshift.py:228:0: C0301: Line too long (105/100) (line-too-long)
moc_openshift.py:230:0: C0301: Line too long (111/100) (line-too-long)
moc_openshift.py:266:0: C0301: Line too long (119/100) (line-too-long)
moc_openshift.py:280:0: C0301: Line too long (118/100) (line-too-long)
moc_openshift.py:424:0: C0301: Line too long (114/100) (line-too-long)
moc_openshift.py:430:0: C0301: Line too long (107/100) (line-too-long)
moc_openshift.py:435:0: C0301: Line too long (107/100) (line-too-long)
moc_openshift.py:447:0: C0301: Line too long (114/100) (line-too-long)
moc_openshift.py:1:0: C0114: Missing module docstring (missing-module-docstring)
moc_openshift.py:9:0: C0115: Missing class docstring (missing-class-docstring)
moc_openshift.py:15:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:19:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:23:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:27:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:35:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:42:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:45:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:48:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:48:4: R0201: Method could be a function (no-self-use)
moc_openshift.py:54:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:64:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:79:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:87:29: W1309: Using an f-string that does not have any interpolated variables (f-string-without-interpolation)
moc_openshift.py:94:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:105:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:107:11: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:111:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:114:17: R1714: Consider merging these comparisons with "in" to 'user.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:117:21: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
moc_openshift.py:123:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:136:11: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:147:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:166:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:203:16: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:204:12: R1705: Unnecessary "elif" after "return" (no-else-return)
moc_openshift.py:208:19: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:252:11: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:305:15: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:166:4: R0911: Too many return statements (12/6) (too-many-return-statements)
moc_openshift.py:166:4: R0912: Too many branches (23/12) (too-many-branches)
moc_openshift.py:333:0: C0115: Missing class docstring (missing-class-docstring)
moc_openshift.py:336:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:339:11: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:343:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:359:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:369:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:379:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:384:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:387:11: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
moc_openshift.py:391:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:401:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:412:4: C0116: Missing function or method docstring (missing-function-docstring)
moc_openshift.py:429:4: C0116: Missing function or method docstring (missing-function-docstring)

------------------------------------------------------------------
Your code has been rated at 7.61/10 (previous run: 7.61/10, +0.00)

```

And in `wsgi.py`:

```
************* Module wsgi
wsgi.py:244:0: C0301: Line too long (193/160) (line-too-long)
wsgi.py:329:5: W0511: TODO: generalize this in the next version. (fixme)
wsgi.py:1:0: C0114: Missing module docstring (missing-module-docstring)
wsgi.py:17:0: C0115: Missing class docstring (missing-class-docstring)
wsgi.py:18:4: C0103: Class name "__MocOSInt" doesn't conform to PascalCase naming style (invalid-name)
wsgi.py:20:17: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
wsgi.py:19:27: W0613: Unused argument 'version' (unused-argument)
wsgi.py:18:4: R0903: Too few public methods (0/2) (too-few-public-methods)
wsgi.py:17:0: R0903: Too few public methods (1/2) (too-few-public-methods)
wsgi.py:53:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
wsgi.py:51:0: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
wsgi.py:91:7: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
wsgi.py:112:7: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
wsgi.py:148:29: E1101: Instance of 'MocOpenShift4x' has no 'cnvt_project_name' member (no-member)
wsgi.py:168:12: W1201: Use lazy % formatting in logging functions (logging-not-lazy)
wsgi.py:173:11: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
wsgi.py:199:11: R1714: Consider merging these comparisons with "in" to 'result.status_code in (200, 201)' (consider-using-in)
wsgi.py:255:11: R1714: Consider merging these comparisons with "in" to 'result.status_code not in (200, 201)' (consider-using-in)
wsgi.py:258:21: W1309: Using an f-string that does not have any interpolated variables (f-string-without-interpolation)
wsgi.py:270:11: R1714: Consider merging these comparisons with "in" to 'result.status_code not in (200, 201)' (consider-using-in)
wsgi.py:285:11: R1714: Consider merging these comparisons with "in" to 'result.status_code not in (200, 201)' (consider-using-in)
wsgi.py:319:11: R1714: Consider merging these comparisons with "in" to 'result.status_code not in (200, 201)' (consider-using-in)
wsgi.py:337:11: R1714: Consider merging these comparisons with "in" to 'result.status_code not in (200, 201)' (consider-using-in)

------------------------------------------------------------------
Your code has been rated at 8.04/10 (previous run: 8.04/10, +0.00)

```