### PR TITLE
Add support for automatic linting

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,30 @@
+name: Pre-commit
+on:
+  push:
+  pull_request:
+
+jobs:
+  run-linters:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install pre-commit
+        run: |
+          pip install pre-commit
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
+
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 21.12b0
+    hooks:
+      - id: black
+        language_version: python3.9
+
+  # Pylint must be run from a *local* hook because it performs
+  # dynamic analysis that won't work when running from the isolated
+  # virtual environment that pre-commit uses by default.
+  #
+  # See https://github.com/pre-commit/pre-commit-hooks/issues/157
+  # for details.
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types:
+          - python
+        require_serial: true

--- a/build.py
+++ b/build.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+# pylint: skip-file
+
 # To run:
 #    1) login as cluster admin
 #        oc login -u [cluster-admin account] -

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest_check
 requests
+pylint


### PR DESCRIPTION
This pull request adds the necessary configuration to run `black` and `pylint` automatically as part of pull requests and pushes. It makes the following changes:

- Adds a configuration for [pre-commit](https://pre-commit.com/).
- Adds a GitHub [action](https://docs.github.com/en/actions/learn-github-actions) that runs `pre-commit` automatically on pull requests and pushes

Quoting from one of the commit messages:

>  To enable these checks in your local repository, install the
>  `pre-commit` tool:
>
>     pip install pre-commit
>
> And then enable the hook in your working directory:
>
>     pre-commit install

This will then run these checks in your local `pre-commit` hook.