### PR TITLE
Treat OPENSHIFT_URL like a URL

### DIFF
--- a/moc_openshift.py
+++ b/moc_openshift.py
@@ -49,7 +49,9 @@ class MocOpenShift(metaclass=abc.ABCMeta):
         }
 
     def set_url(self, url):
-        self.url = "https://" + url
+        if not url.startswith("http"):
+            url = f"https://{url}"
+        self.url = url
 
     def get_url(self):
         return self.url


### PR DESCRIPTION
The variable is called OPENSHIFT_URL, so let's allow it to be a URL.
This is convenient during testing because we can simply set:

    OPENSHIFT_URL=$(oc whoami --show-server)