### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
 FROM python:3.8
 
-RUN mkdir -p /app
 WORKDIR /app
 
-COPY wsgi.py /app/wsgi.py
-COPY moc_openshift.py /app/moc_openshift.py
-COPY start.sh /app/start.sh
-COPY requirements.txt /app/requirements.txt
-COPY config.py /app/config.py
+COPY requirements.txt .
+RUN pip install -r requirements.txt 
 
-RUN cd /app \
- && pip3 install -r requirements.txt 
+COPY wsgi.py moc_openshift.py start.sh config.py .
 
 CMD ["/app/start.sh"]
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-cd /app
-gunicorn -b 0.0.0.0:8080 -c /app/config.py -e PYTHONBUFFERED=TRUE wsgi:APP --log-file=-
+exec gunicorn -b 0.0.0.0:8080 -c config.py -e PYTHONBUFFERED=TRUE wsgi:APP --log-file=-
 


### PR DESCRIPTION
1. When building Python container images, it is best practice to
   install requirements before installing the project code. This
   allows you to take advantage of layer caching and avoid
   re-installing the requirements every time you rebuild the image.

2. Because of the 'WORKDIR /app' in the Dockerfile, /app is the
   current working directory for all following operations. This fact
   allows us to simplify the remainder of the Dockerfile and the
   start.sh script.
