### PR TITLE
Allow service to run locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM python:3.8
 
+RUN mkdir -p /app
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt 
 
-COPY wsgi.py moc_openshift.py start.sh config.py .
+COPY wsgi.py moc_openshift.py start.sh config.py ./
 
 CMD ["/app/start.sh"]
 

--- a/README.md
+++ b/README.md
@@ -75,3 +75,38 @@ oc login -u system:admin
 oc adm policy add-cluster-role-to-user cluster-admin developer"
 oc login -u developer
 docker login -u developer -p developer 172.30.1.1:5000
+
+## Running the service locally
+
+You will need to make sure you are authenticated to OpenShift (when
+run locally, we use `oc whoami -t` to get an authentication token).
+
+You will need to set the following environment variables:
+
+```
+OPENSHIFT_URL=$(oc whoami --show-server)
+ACCT_MGT_IDENTITY_PROVIDER=developer
+ACCT_MGT_ADMIN_PASSWORD=pass
+```
+
+Then start the server up like this:
+
+```
+ACCT_MGT_AUTH_TOKEN=$(oc whoami -t) \
+flask run -p 8080
+```
+
+Or alternately:
+
+```
+ACCT_MGT_AUTH_TOKEN=$(oc whoami -t) \
+gunicorn -b 127.0.0.1:8080 -c config.py wsgi:APP
+```
+
+This will expose the microservice on http://127.0.0.1:8080. You can
+access it like this:
+
+```
+$ curl -u admin:pass  http://localhost:8080/users/test-user
+{"msg": "user (test-user) does not exist"}
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask
 kubernetes
 openshift
 flask_httpauth
+python-dotenv

--- a/wsgi.py
+++ b/wsgi.py
@@ -13,6 +13,7 @@ AUTH = HTTPBasicAuth()
 OPENSHIFT_URL = os.environ["OPENSHIFT_URL"]
 ADMIN_USERNAME = os.environ.get("ACCT_MGT_ADMIN_USERNAME", "admin")
 ADMIN_PASSWORD = os.environ["ACCT_MGT_ADMIN_PASSWORD"]
+AUTH_TOKEN = os.environ.get("ACCT_MGT_AUTH_TOKEN")
 
 if __name__ != "__main__":
     APP.logger = logging.getLogger("gunicorn.error")
@@ -28,12 +29,14 @@ class MocOpenShiftSingleton:
         """Wrapper for API openshift API class"""
 
         def __init__(self, url, logger):
-            with open(
-                "/var/run/secrets/kubernetes.io/serviceaccount/token", "r"
-            ) as file:
-                token = file.read()
-                self.shift = moc_openshift.MocOpenShift4x(url, token, logger)
-                APP.logger.info("using Openshift ver 4")
+            token = AUTH_TOKEN
+            if token is None:
+                with open(
+                    "/var/run/secrets/kubernetes.io/serviceaccount/token", "r"
+                ) as file:
+                    token = file.read()
+            self.shift = moc_openshift.MocOpenShift4x(url, token, logger)
+            APP.logger.info("using Openshift ver 4")
 
     openshift_instance = None
 


### PR DESCRIPTION
With this set of changes, it becomes easy to run the microservice locally without first deploying it into openshift. Assuming that you have a CRC up and running, and you are authenticated to it using the `oc` cli, you can run the service like this:

```
OPENSHIFT_URL=$(oc whoami --show-server) ACCT_MGT_ADMIN_PASSWORD=pass \
ACCT_MGT_IDENTITY_PROVIDER=developer ACCT_MGT_AUTH_TOKEN=$(oc whoami -t) \
flask run -p 8080
```

If you have installed the `python-dotenv` package, `flask` will read
environment variables from `.env` file in the current directory when
it starts up, so you can put the static settings into your `.env`
file:

```
OPENSHIFT_URL=https://api.crc.testing:6443
ACCT_MGT_ADMIN_PASSWORD=pass
ACCT_MGT_IDENTITY_PROVIDER=developer
```

And then run `flask` like this:

```
ACCT_MGT_AUTH_TOKEN=$(oc whoami -t) flask run -p 8080
```

With the service up and running, you can interact with it using `curl`
or [httpie][]:

```
$ http --auth admin:pass PUT localhost:8080/users/test-user
HTTP/1.0 200 OK
Content-Length: 35
Content-Type: application/json
Date: Wed, 15 Dec 2021 18:12:36 GMT
Server: Werkzeug/2.0.2 Python/3.10.0

{
    "msg": "user created (test-user)"
}
```


[httpie]: https://httpie.io/cli