### PR TITLE
Dockerfile fixes for quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM python:3.8
 
+RUN mkdir -p /app
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt 
 
-COPY wsgi.py moc_openshift.py start.sh config.py .
+COPY wsgi.py moc_openshift.py start.sh config.py ./
 
 CMD ["/app/start.sh"]
 


### PR DESCRIPTION
I'd like to arrange for this to build automatically at
quay.io/massopencloud/openshift-acct-mgt, but it looks like the
quay.io builder may behave differently than docker/podman/buildah in
that the `WORKDIR` directive doesn't create the target directory.
