### PR TITLE
Minimal quota support (revised)

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 """ This is a config files used by gunicorn """
 # Disabling the pylint message about the 'forward_allowed_ips' even
 # as this is a constanst defined by gunicorn.
-# pylint: disable=C0103
+# pylint: disable=invalid-name
 import os
 
 workers = int(os.environ.get("GUNICORN_PROCESSES", "3"))

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -20,5 +20,13 @@ spec:
         ports:
         - containerPort: 8080
           protocol: TCP
+        volumeMounts:
+          - name: quota-vol
+            mountPath: /app/quota
+            readOnly: true
       serviceAccountName: onboarding-serviceaccount
       automountServiceAccountToken: True
+      volumes:
+        - name: quota-vol
+          configMap: 
+            name: openshift-quota-definition 

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,6 +15,8 @@ spec:
           value: KUSTOMIZE
         - name: ACCT_MGT_IDENTITY_PROVIDER
           value: KUSTOMIZE
+        - name: ACCT_MGT_QUOTA_DEF_FILE
+          value: KUSTOMIZE
         image: KUSTOMIZE
         imagePullPolicy: Always
         ports:

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -3,6 +3,7 @@ commonLabels:
 namespace: onboarding
 resources:
 - cluster-role-binding.yaml
+- quotaConfigmap.yaml
 - deployment.yaml
 - image-stream.yaml
 - route.yaml

--- a/k8s/base/quotaConfigmap.yaml
+++ b/k8s/base/quotaConfigmap.yaml
@@ -1,0 +1,39 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openshift-quota-definition
+data:
+  quota: |- 
+    { 
+    ":persistentvolumeclaims":        { "base": 2, "coefficient": 0 }, 
+    ":requests.storage":              { "base": 2, "coefficient": 0 },
+    ":requests.ephemeral-storage":    { "base": 2, "coefficient": 8, "units": "Gi"  },
+    ":limits.ephemeral-storage":      { "base": 2, "coefficient": 8, "units": "Gi"  },
+    ":replicationcontrollers":        { "base": 2, "coefficient": 0 },
+    ":resourcequotas":                { "base": 5, "coefficient": 0 },
+    ":services":                      { "base": 4, "coefficient": 0 },
+    ":services.loadbalancers":        { "base": 2, "coefficient": 0 },
+    ":services.nodeports":            { "base": 2, "coefficient": 0 },
+    ":secrets":                       { "base": 4, "coefficient": 0 },
+    ":configmaps":                    { "base": 4, "coefficient": 0 },
+    ":openshift.io/imagestreams":     { "base": 2, "coefficient": 0 },
+    "BestEffort:pods":                { "base": 2, "coefficient": 2 },
+    "NotBestEffort:pods":             { "base": 2, "coefficient": 2 },
+    "NotBestEffort:requests.memory":  { "base": 2, "coefficient": 4, "units": "Gi"  },
+    "NotBestEffort:limits.memory":    { "base": 2, "coefficient": 4, "units": "Gi"  },
+    "NotBestEffort:requests.cpu":     { "base": 2, "coefficient": 2 },
+    "NotBestEffort:limits.cpu":       { "base": 2, "coefficient": 2 },
+    "Terminating:pods":               { "base": 2, "coefficient": 2 },
+    "Terminating:requests.memory":    { "base": 2, "coefficient": 4, "units": "Gi"  },
+    "Terminating:limits.memory":      { "base": 2, "coefficient": 4, "units": "Gi"  },
+    "Terminating:requests.cpu":       { "base": 2, "coefficient": 2 },
+    "Terminating:limits.cpu":         { "base": 2, "coefficient": 2 },
+    "NotTerminating:pods":            { "base": 2, "coefficient": 2 },
+    "NotTerminating:requests.memory": { "base": 2, "coefficient": 4, "units": "Gi"  },
+    "NotTerminating:limits.memory":   { "base": 2, "coefficient": 4, "units": "Gi"  },
+    "NotTerminating:requests.cpu":    { "base": 2, "coefficient": 2 },
+    "NotTerminating:limits.cpu":      { "base": 2, "coefficient": 2 }
+    }
+
+
+

--- a/k8s/overlays/rbb-crc/patches/deployment.yaml
+++ b/k8s/overlays/rbb-crc/patches/deployment.yaml
@@ -15,6 +15,8 @@ spec:
             value: "4"
           - name: ACCT_MGT_IDENTITY_PROVIDER
             value: "Developer"
+          - name: ACCT_MGT_QUOTA_DEF_FILE
+            value: /app/quota_def/quota
         image: "docker.io/robertbartlettbaron/acct-mgt.x86:latest"
         volumeMounts:
           - name: auth-vol

--- a/k8s/overlays/rbb-crc/patches/deployment.yaml
+++ b/k8s/overlays/rbb-crc/patches/deployment.yaml
@@ -24,3 +24,4 @@ spec:
         - name: auth-vol
           secret:
             secretName: basic-auth
+

--- a/moc_openshift.py
+++ b/moc_openshift.py
@@ -1,5 +1,5 @@
 """API wrapper for interacting with OpenShift authorization"""
-# pylint: disable=R0904
+# pylint: disable=too-many-public-methods
 import abc
 import pprint
 import json
@@ -75,8 +75,9 @@ class MocOpenShift(metaclass=abc.ABCMeta):
     def get_url(self):
         return self.url
 
-    # pylint: disable=no-self-use
-    def cnvt_project_name(self, project_name):
+
+    @staticmethod
+    def cnvt_project_name(project_name):
         suggested_project_name = re.sub("^[^A-Za-z0-9]+", "", project_name)
         suggested_project_name = re.sub("[^A-Za-z0-9]+$", "", suggested_project_name)
         suggested_project_name = re.sub("[^A-Za-z0-9-]+", "-", suggested_project_name)
@@ -400,7 +401,8 @@ class MocOpenShift(metaclass=abc.ABCMeta):
             mimetype="application/json",
         )
 
-    def get_quota_definitions(self):
+    @staticmethod
+    def get_quota_definitions():
         with open("/app/quota/quota", "r") as file:
             quota = json.loads(file.read())
         for k in quota:

--- a/tests/amt_helper.py
+++ b/tests/amt_helper.py
@@ -155,11 +155,7 @@ def ms_user_project_remove_role(acct_mgt_url, role_info, session):
 
 def is_moc_quota_empty(moc_quota) -> bool:
     """This checks to see if an moc quota (name mangled) is empty"""
-    if "Quota" in moc_quota:
-        for item in moc_quota["Quota"]:
-            if moc_quota["Quota"][item] is not None:
-                return False
-    return True
+    return all(item is None for item in moc_quota.get("Quota", []))
 
 
 def ms_get_moc_quota(acct_mgt_url, project_name, auth_opts=None) -> dict:

--- a/tests/amt_helper.py
+++ b/tests/amt_helper.py
@@ -32,7 +32,7 @@ def compare_results(result, pattern):
     return False
 
 
-def oc_resource_exist(resource, kind, name, project=None):
+def oc_resource_exist(resource, kind, name, project=None) -> bool:
     """This uses oc to determine if an openshift resource exists"""
     cmd = ["oc", "-o", "json"]
     if project is not None:

--- a/tests/amt_quota_test.py
+++ b/tests/amt_quota_test.py
@@ -1,0 +1,53 @@
+""" tests adding quotas to projects """
+
+import pytest_check as check
+import amt_helper as amt
+
+
+def test_quota(acct_mgt_url, auth_opts):
+    """This tests quota support on the microserver"""
+    # 1) Create a project
+    project_name = "test-003"
+    if not amt.oc_resource_exist("project", "Project", project_name):
+        check.is_true(
+            amt.ms_create_project(acct_mgt_url, project_name, None, auth_opts),
+            f"Project ({project_name}) was unable to be created",
+        )
+    check.is_true(
+        amt.oc_resource_exist("project", "Project", project_name),
+        f"Project ({project_name}) does not exist",
+    )
+
+    # 2) Check to see that the quota is empty
+    check.is_false(
+        amt.oc_resource_exist("resourcequota", "ResourceQuota", None, project_name),
+        "Error, unexpected quota as it should be empty",
+    )
+
+    # 3) Can we delete an empty quota?
+    check.is_false(
+        amt.ms_del_moc_quota(acct_mgt_url, project_name, auth_opts),
+        "Error: Empty quota deleted",
+    )
+
+    # 4) Create a quota using the QuotaMultiplier as adjutant/coldfront will initially do
+    amt.ms_put_moc_quota(
+        acct_mgt_url,
+        project_name,
+        {
+            "Version": "0.9",
+            "Kind": "MocQuota",
+            "ProjectName": "rbb-test",
+            "Quota": {"QuotaMultiplier": 1},
+        },
+        auth_opts,
+    )
+    check.is_true(
+        amt.oc_resource_exist("resourcequota", "ResourceQuota", None, project_name),
+        "quotas not there, but should be",
+    )
+    # cleanup after testing
+    check.is_true(
+        amt.ms_delete_project(acct_mgt_url, project_name, auth_opts) is True,
+        "project (test-002) deleted",
+    )

--- a/wsgi.py
+++ b/wsgi.py
@@ -365,7 +365,7 @@ def get_quota(project):
     shift = get_openshift()
     return Response(
         response=json.dumps(shift.get_moc_quota(project)),
-        status=400,
+        status=200,
         mimetype="application/json",
     )
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -359,5 +359,31 @@ def delete_moc_user(user_name):
     )
 
 
+@APP.route("/projects/<project>/quota", methods=["GET"])
+@AUTH.login_required
+def get_quota(project):
+    shift = get_openshift()
+    return Response(
+        response=json.dumps(shift.get_moc_quota(project)),
+        status=400,
+        mimetype="application/json",
+    )
+
+
+@APP.route("/projects/<project>/quota", methods=["PUT", "POST"])
+@AUTH.login_required
+def put_quota(project):
+    shift = get_openshift()
+    moc_quota = request.get_json(force=True)
+    return shift.replace_moc_quota(project, moc_quota)
+
+
+@APP.route("/projects/<project>/quota", methods=["DELETE"])
+@AUTH.login_required
+def delete_quota(project):
+    shift = get_openshift()
+    return shift.delete_moc_quota(project)
+
+
 if __name__ == "__main__":
     APP.run()


### PR DESCRIPTION
@rob-baron in an [earlier review](https://github.com/CCI-MOC/openshift-acct-mgt/pull/51#pullrequestreview-834576850), @naved001 commented on the use of "merge" vs "rebase" when introducing changes from another branch into your code.

This pull request is identical to #41, but I've used `git rebase` to clean it up by eliminating the merge commits (and editing the commit summary in a few cases to make them match [common commit message conventions](https://github.com/CCI-MOC/ops-docs/blob/master/specs/0007-pull-requests.md)). This results in a commit history that's easier to follow. 

Compare:

```
$ git log --oneline dace1921..MinimalQuotaSupport-clean
19693aa Changes made based on comments in the review
dd3575e Use symbolic names rather than numbers when disabling pylint errors
ef12fad Add the initial test for quota support
34a60d3 Add the functions for testing quotas
5123597 Return successful status code from get_quota
d0fc6ad And the quota configmap
f865502 Add minimal quota support
```

To:

```
$ git log --oneline dace1921..MinimalQuotaSupport
c2de68c Changes made based on comments in the review
bb8a649 Changing pylint error numbers to symbolic messages as this is larsks' preference
3f65144 Added the initial test for quota support.
d06189b Added the functions for testing quotas
b0a25e0 Merge branch 'master' into MinimalQuotaSupport
df2e816 Should always return success as this function is returning the quota list from the configmap.
d1e77e9 I now saved the resolved merge file
0ca230b Merge branch 'master' into MinimalQuotaSupport
612b3ca And finally the quota configmap
516dd6d This is a minimal support of quotas that is sufficient to support initial Adjutant/Coldfront integration
1beee01 Environment variable is now ACCT_MGT_IDENTITY_PROVIDER
e1df448 This commit finishes the badly done merger of the previous commit.
f6aa735 Merge branch 'master' into IdentityProviderFromConfigMap
a44b0fc removed a vestage of getting a configmap from the openshift api
13a4f7d makes the changes requested and implied by the reviewers.
05d79f4 Changes to the patches to support basic authentication in order to test specifying the identity provider as an environment variable.
7879752 This just removes the reading in of the namespace
57d3e65 Merge branch 'master' of https://github.com/CCI-MOC/openshift-acct-mgt into IdentityProviderFromConfigMap
14d9ee3 Merge branch 'master' of https://github.com/CCI-MOC/openshift-acct-mgt into IdentityProviderFromConfigMap
0219d7c Now fetching the identity provider from a configmap.
899b966 This just pylints config.py
```

In particular, this PR doesn't include commits from changes that were already merged into `master`. The content is identical to #41 (except for a single blank line):

```
$ git diff MinimalQuotaSupport-clean MinimalQuotaSupport
diff --git a/k8s/overlays/rbb-crc/patches/deployment.yaml b/k8s/overlays/rbb-crc/patches/deployment.yaml
index 890007e..119535f 100644
--- a/k8s/overlays/rbb-crc/patches/deployment.yaml
+++ b/k8s/overlays/rbb-crc/patches/deployment.yaml
@@ -26,4 +26,3 @@ spec:
         - name: auth-vol
           secret:
             secretName: basic-auth
-
```

Having a clean commit history like this makes it a bit easier to understand what's going on.

