### PR TITLE
Remove role mappings between openstack and openshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ It implements the following functions:
 
         oc create project <project-name>
 
-    3) Add a user to a project with a given role.  Here the role may be one of 'admin', 'member' or 'reader'.  In OpenShift, these roles are 'admin', 'edit', 'view' respectively.
+    3) Add a user to a project with a given role. In OpenShift, these roles are 'admin', 'edit', 'view' respectively.
 
         a) API call:
 
-            get [cluster url]/users/<user-name>/projects/<project-name>/roles/<admin|member|reader>
+            get [cluster url]/users/<user-name>/projects/<project-name>/roles/<admin|edit|view>
 
         b) Equivalent command line commands:
 
@@ -60,7 +60,7 @@ It implements the following functions:
 
         a) API call:
         
-            delete [cluster url]/users/<user-name>/projects/<project-name>/roles/<admin|member|reader>   
+            delete [cluster url]/users/<user-name>/projects/<project-name>/roles/<admin|edit|view>   
         b) Equivalent command line commands:
     
             oc adm policy -n <project-name> rm-role-from-user <admin|edit|view> <user-name>

--- a/acct_mgt/app.py
+++ b/acct_mgt/app.py
@@ -66,7 +66,7 @@ def create_app(**config):
     )
     @AUTH.login_required
     def get_moc_rolebindings(project_name, user_name, role):
-        # role can be one of Admin, Member, Reader
+        # role can be one of admin, edit, view
         if shift.user_rolebinding_exists(user_name, project_name, role):
             return Response(
                 response=json.dumps(
@@ -88,7 +88,7 @@ def create_app(**config):
     )
     @AUTH.login_required
     def create_moc_rolebindings(project_name, user_name, role):
-        # role can be one of Admin, Member, Reader
+        # role can be one of admin, edit, view
         result = shift.update_user_role_project(project_name, user_name, role, "add")
         if result.status_code in (200, 201):
             return Response(
@@ -107,7 +107,7 @@ def create_app(**config):
     )
     @AUTH.login_required
     def delete_moc_rolebindings(project_name, user_name, role):
-        # role can be one of Admin, Member, Reader
+        # role can be one of admin, edit, view
         result = shift.update_user_role_project(project_name, user_name, role, "del")
         if result.status_code in (200, 201):
             return Response(


### PR DESCRIPTION
The accepted roles are now 'admin', 'edit', and 'view'

The role mapping from admin -> admin, member -> edit, and
reader -> view, was a remnant from when were were trying to
integrate this into Adjutant, which used OpenStack role
names.

Instead now just accept the openshift roles directly without doing any mapping.