### PR TITLE
Return 404 when user not found

### DIFF
--- a/acct_mgt/app.py
+++ b/acct_mgt/app.py
@@ -218,7 +218,7 @@ def create_app(**config):
             )
         return Response(
             response=json.dumps({"msg": f"user ({user_name}) does not exist"}),
-            status=400,
+            status=404,
             mimetype="application/json",
         )
 

--- a/tests/functional/test_user.py
+++ b/tests/functional/test_user.py
@@ -21,15 +21,6 @@ def test_get_user_notfound(session):
     that does not exist"""
 
     res = session.get("/users/does-not-exist")
-    assert res.status_code == 400
-
-
-@pytest.mark.xfail(reason="not supported by service")
-def test_get_user_notfound_404(session):
-    """Test that an attempt to get information about a user that does not
-    exist results in a 404 NOTFOUND response code"""
-
-    res = session.get("/users/does-not-exist")
     assert res.status_code == 404
 
 

--- a/tests/unit/test_app_user.py
+++ b/tests/unit/test_app_user.py
@@ -19,7 +19,7 @@ def test_get_moc_user_exists(moc, client):
 def test_get_moc_user_not_exists(moc, client):
     moc.user_exists.return_value = False
     res = client.get("/users/test-user")
-    assert res.status_code == 400
+    assert res.status_code == 404
     moc.user_exists.assert_called_with("test-user")
 
 


### PR DESCRIPTION
It's hard to distinguish between a bad request and a good request
but without an existing user.