### PR TITLE
Fix missing kind in roleRef

### DIFF
--- a/acct_mgt/moc_openshift.py
+++ b/acct_mgt/moc_openshift.py
@@ -442,7 +442,7 @@ class MocOpenShift4x(MocOpenShift):
             "metadata": {"name": role, "namespace": project_name},
             "groupNames": None,
             "userNames": [user_name],
-            "roleRef": {"name": role},
+            "roleRef": {"name": role, "kind": "Role"},
         }
         return self.client.post(url, json=payload)
 


### PR DESCRIPTION
This fixed an issue with being unable to create rolebindings.

```
url = 'http://localhost:8001/apis/rbac.authorization.k8s.io/v1/namespaces/44af5af5d2ae44ed85de55a3d0556b3c/rolebindings'
>>> payload = {
...     "kind": "RoleBinding",
...     "apiVersion": "rbac.authorization.k8s.io/v1",
...     "metadata": {"name": role, "namespace": project_name},
...     "groupNames": None,
...     "userNames": [user_name],
...     "roleRef": {"name": role, "kind": "Role"},
... }
>>> requests.post(url, json=payload)
<Response [201]>
>>> requests.delete(url + '/edit')
<Response [200]>
>>> payload["roleRef"].pop("kind")
'Role'
>>> requests.post(url, json=payload)
<Response [422]>
>>> _.text
'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"RoleBinding.rbac.authorization.k8s.io \\"edit\\" is invalid: roleRef.kind: Unsupported value: \\"\\": supported values: \\"Role\\", \\"ClusterRole\\"","reason":"Invalid","details":{"name":"edit","group":"rbac.authorization.k8s.io","kind":"RoleBinding","causes":[{"reason":"FieldValueNotSupported","message":"Unsupported value: \\"\\": supported values: \\"Role\\", \\"ClusterRole\\"","field":"roleRef.kind"}]},"code":422}\n'
>>> 
```