### PR TITLE
Fix rolebinding functions to use subjects

### DIFF
--- a/acct_mgt/moc_openshift.py
+++ b/acct_mgt/moc_openshift.py
@@ -86,12 +86,12 @@ class MocOpenShift(metaclass=abc.ABCMeta):
         if result.status_code in (200, 201):
             role_binding = result.json()
             self.logger.info(f"rolebinding result:\n{pprint.pformat(role_binding)}")
-            if (
-                "userNames" in role_binding.keys()
-                and role_binding["userNames"] is not None
-                and user_name in role_binding["userNames"]
-            ):
-                return True
+            users_in_role = [
+                u["name"]
+                for u in role_binding.get("subjects", {})
+                if u["kind"] == "User"
+            ]
+            return user_name in users_in_role
         return False
 
     def get_all_moc_rolebindings(self, user, project_name):

--- a/acct_mgt/moc_openshift.py
+++ b/acct_mgt/moc_openshift.py
@@ -440,8 +440,7 @@ class MocOpenShift4x(MocOpenShift):
             "kind": "RoleBinding",
             "apiVersion": "rbac.authorization.k8s.io/v1",
             "metadata": {"name": role, "namespace": project_name},
-            "groupNames": None,
-            "userNames": [user_name],
+            "subjects": [{"name": user_name, "kind": "User"}],
             "roleRef": {"name": role, "kind": "Role"},
         }
         return self.client.post(url, json=payload)


### PR DESCRIPTION
Role bindings in the k8s authorization API put the users of the
rolebinding in the subjects fields, which is a list of User or
Group objects.