### PR TITLE
Fix unit test failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3.9

--- a/acct_mgt/app.py
+++ b/acct_mgt/app.py
@@ -156,12 +156,9 @@ def create_app(**config):
                 mimetype="application/json",
             )
         if not shift.project_exists(project_uuid):
-            if request.json:
-                project_name = request.json.get("displayName", project_uuid)
-                APP.logger.debug("create project json: %s", project_name)
-            else:
-                project_name = project_uuid
-                APP.logger.debug("create project json: None")
+            project_name = (request.get_json(silent=True) or {}).get(
+                "displayName", project_uuid
+            )
 
             result = shift.create_project(project_uuid, project_name, user_name)
             if result.status_code in (200, 201):


### PR DESCRIPTION
When making an API request without specifying the mimetype to json,
request.json would thrown a 400 Bad Request error.

This patch makes the error silent since we don't care about the mimetype
when no json is required in payload and some clients don't set it by
default when no payload either.

Also removed conditional, since `.get` provides a default on key absence. 