### PR TITLE
Adds annotations when creating projects

### DIFF
--- a/acct_mgt/app.py
+++ b/acct_mgt/app.py
@@ -142,6 +142,7 @@ def create_app(**config):
     def create_moc_project(project_uuid, user_name=None):
         # first check the project_name is a valid openshift project name
         suggested_project_name = shift.cnvt_project_name(project_uuid)
+
         if project_uuid != suggested_project_name:
             # future work, handel colisons by suggesting a different valid
             # project name
@@ -156,11 +157,12 @@ def create_app(**config):
                 mimetype="application/json",
             )
         if not shift.project_exists(project_uuid):
-            project_name = (request.get_json(silent=True) or {}).get(
-                "displayName", project_uuid
+            payload = request.get_json(silent=True) or {}
+            project_name = payload.pop("displayName", project_uuid)
+            annotations = payload.pop("annotations", {})
+            result = shift.create_project(
+                project_uuid, project_name, user_name, annotations=annotations
             )
-
-            result = shift.create_project(project_uuid, project_name, user_name)
             if result.status_code in (200, 201):
                 return Response(
                     response=json.dumps({"msg": f"project created ({project_uuid})"}),

--- a/acct_mgt/moc_openshift.py
+++ b/acct_mgt/moc_openshift.py
@@ -355,19 +355,19 @@ class MocOpenShift4x(MocOpenShift):
             return True
         return False
 
-    def create_project(self, project_name, display_name, user_name):
+    def create_project(self, project_name, display_name, user_name, annotations=None):
         # check project_name
+        if annotations is None:
+            annotations = {}
+        else:
+            annotations = dict(annotations)
         url = "/apis/project.openshift.io/v1/projects/"
+        annotations["openshift.io/display-name"] = display_name
+        annotations["openshift.io/requester"] = user_name
         payload = {
             "kind": "Project",
             "apiVersion": "project.openshift.io/v1",
-            "metadata": {
-                "name": project_name,
-                "annotations": {
-                    "openshift.io/display-name": display_name,
-                    "openshift.io/requester": user_name,
-                },
-            },
+            "metadata": {"name": project_name, "annotations": annotations},
         }
         return self.client.post(url, json=payload)
 

--- a/tests/unit/test_app_project.py
+++ b/tests/unit/test_app_project.py
@@ -32,7 +32,9 @@ def test_create_moc_project_no_display_name(moc, client):
     moc.create_project.return_value = fake_200_response
     res = client.put("/projects/test-project")
     assert res.status_code == 200
-    moc.create_project.assert_called_with("test-project", "test-project", None)
+    moc.create_project.assert_called_with(
+        "test-project", "test-project", None, annotations={}
+    )
 
 
 def test_create_moc_project_with_display_name(moc, client):
@@ -45,7 +47,25 @@ def test_create_moc_project_with_display_name(moc, client):
         content_type="application/json",
     )
     assert res.status_code == 200
-    moc.create_project.assert_called_with("test-project", "Test Project", None)
+    moc.create_project.assert_called_with(
+        "test-project", "Test Project", None, annotations={}
+    )
+
+
+def test_create_moc_project_with_annotations(moc, client):
+    moc.cnvt_project_name.return_value = "test-project"
+    moc.project_exists.return_value = False
+    moc.create_project.return_value = fake_200_response
+    annotations = {"cf_pi": "1"}
+    res = client.put(
+        "/projects/test-project",
+        data=json.dumps({"annotations": annotations}),
+        content_type="application/json",
+    )
+    assert res.status_code == 200
+    moc.create_project.assert_called_with(
+        "test-project", "test-project", None, annotations=annotations
+    )
 
 
 def test_create_moc_project_exists(moc, client):


### PR DESCRIPTION
Adds the ability to create users with annotations passed as json
when creating a user on the PUT /users/<username> url. Annotations
will be useful for NERC onboarding for retrieving hierarchical
information in XDMOD