### PR TITLE
Change kind of Role to ClusterRole

### DIFF
--- a/acct_mgt/moc_openshift.py
+++ b/acct_mgt/moc_openshift.py
@@ -443,7 +443,7 @@ class MocOpenShift4x(MocOpenShift):
             "apiVersion": "rbac.authorization.k8s.io/v1",
             "metadata": {"name": role, "namespace": project_name},
             "subjects": [{"name": user_name, "kind": "User"}],
-            "roleRef": {"name": role, "kind": "Role"},
+            "roleRef": {"name": role, "kind": "ClusterRole"},
         }
         return self.client.post(url, json=payload)
 


### PR DESCRIPTION
During testing in ocp-staging, the project doesn't show up for the user
since there is no kind Role in the namespace. This is fixed by
creating a RoleBinding with the ClusterRole on the namespace.

It appears that the OpenShift dashboard does also add the ClusterRole
when adding users to a project through the form instead of a Role as
seen below with.

```
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: test@example.com-edit-6daeb68123ea4a2e
  namespace: de0e163455c34e4dbed65e72ca765651
  uid: d2a32a6d-d845-46bd-9757-ebfaf885d938
  resourceVersion: '545901838'
  creationTimestamp: '2022-08-24T17:43:53Z'
  managedFields:
    - manager: Mozilla
      operation: Update
      apiVersion: rbac.authorization.k8s.io/v1
      time: '2022-08-24T17:43:53Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:roleRef': {}
        'f:subjects': {}
subjects:
  - kind: User
    apiGroup: rbac.authorization.k8s.io
    name: test@example.com
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: edit
```