### PR TITLE
Increase default limits

### DIFF
--- a/k8s/base/limits.json
+++ b/k8s/base/limits.json
@@ -2,12 +2,12 @@
     {
         "type": "Container",
         "default": {
-            "cpu": "200m",
-            "memory": "512Mi"
+            "cpu": "2",
+            "memory": "1024Mi"
         },
         "defaultRequest": {
-            "cpu": "100m",
-            "memory": "256Mi"
+            "cpu": "1",
+            "memory": "512Mi"
         }
     }
 ]


### PR DESCRIPTION
The default limitrange introduced in d62b270 were small enough to prevent
basic use of the cluster (see the linked issue). This commits raises the
limits.

Part-of: OCP-on-NERC/operations#90
