### PR TITLE
feature: support for setting project/namespace labels

### DIFF
--- a/acct_mgt/app.py
+++ b/acct_mgt/app.py
@@ -147,9 +147,14 @@ def create_app(**config):
         payload = request.get_json(silent=True) or {}
         display_name = payload.pop("displayName", project_name)
         annotations = payload.pop("annotations", {})
+        labels = payload.pop("labels", {})
 
         shift.create_project(
-            project_name, display_name, user_name, annotations=annotations
+            project_name,
+            display_name,
+            user_name,
+            annotations=annotations,
+            labels=labels,
         )
         return {"msg": f"project created ({project_name})"}
 

--- a/acct_mgt/moc_openshift.py
+++ b/acct_mgt/moc_openshift.py
@@ -168,7 +168,8 @@ class MocOpenShift4x:
             return False
         return True
 
-    def create_project(self, project_name, display_name, user_name, annotations=None):
+    def create_project(self, project_name, display_name, user_name,
+                       annotations=None, labels=None):
         if annotations is None:
             annotations = {}
         else:
@@ -182,9 +183,17 @@ class MocOpenShift4x:
                 "openshift.io/requester": user_name,
             }
         )
-        labels = {
+
+        _nerc_project_label = {
             "nerc.mghpcc.org/project": "true",
         }
+
+        if labels is None:
+            labels = _nerc_project_label
+        else:
+            labels = dict(labels)
+            labels.update(_nerc_project_label)
+
         payload = {
             "metadata": {
                 "name": project_name,

--- a/acct_mgt/moc_openshift.py
+++ b/acct_mgt/moc_openshift.py
@@ -168,8 +168,10 @@ class MocOpenShift4x:
             return False
         return True
 
-    def create_project(self, project_name, display_name, user_name,
-                       annotations=None, labels=None):
+    # pylint: disable-msg=too-many-arguments
+    def create_project(
+        self, project_name, display_name, user_name, annotations=None, labels=None
+    ):
         if annotations is None:
             annotations = {}
         else:
@@ -204,6 +206,8 @@ class MocOpenShift4x:
         res = api.create(body=payload).to_dict()
         self.create_limits(project_name)
         return res
+
+    # pylint: enable-msg=too-many-arguments
 
     def delete_project(self, project_name):
         api = self.get_resource_api(API_PROJECT, "Project")

--- a/tests/unit/app/test_app_project.py
+++ b/tests/unit/app/test_app_project.py
@@ -33,7 +33,7 @@ def test_create_moc_project_no_display_name(moc, client):
     res = client.put("/projects/test-project")
     assert res.status_code == 200
     moc.create_project.assert_called_with(
-        "test-project", "test-project", None, annotations={}
+        "test-project", "test-project", None, annotations={}, labels={}
     )
 
 
@@ -48,7 +48,7 @@ def test_create_moc_project_with_display_name(moc, client):
     )
     assert res.status_code == 200
     moc.create_project.assert_called_with(
-        "test-project", "Test Project", None, annotations={}
+        "test-project", "Test Project", None, annotations={}, labels={}
     )
 
 
@@ -64,7 +64,23 @@ def test_create_moc_project_with_annotations(moc, client):
     )
     assert res.status_code == 200
     moc.create_project.assert_called_with(
-        "test-project", "test-project", None, annotations=annotations
+        "test-project", "test-project", None, annotations=annotations, labels={}
+    )
+
+
+def test_create_moc_project_with_labels(moc, client):
+    moc.cnvt_project_name.return_value = "test-project"
+    moc.project_exists.return_value = False
+    moc.create_project.return_value = {}
+    labels = {"opendatahub.io/dashboard": True}
+    res = client.put(
+        "/projects/test-project",
+        data=json.dumps({"labels": labels}),
+        content_type="application/json",
+    )
+    assert res.status_code == 200
+    moc.create_project.assert_called_with(
+        "test-project", "test-project", None, annotations={}, labels=labels
     )
 
 


### PR DESCRIPTION
This allows for setting namespace/project lables in addition to annotations. This is useful, for example, for adding required labels in order to use RHODS with a given project/namespace.