### PR TITLE
Remove unnecessary metadata from openshift objects

### DIFF
--- a/tests/unit/moc_openshift/test_moc_openshift_clean_metadata.py
+++ b/tests/unit/moc_openshift/test_moc_openshift_clean_metadata.py
@@ -1,0 +1,32 @@
+# pylint: disable=missing-module-docstring
+import pytest
+
+import acct_mgt.moc_openshift
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        ({}, {}),
+        ({"spec": "test"}, {"spec": "test"}),
+        ({"metadata": {}, "spec": "something"}, {"metadata": {}, "spec": "something"}),
+        (
+            {"metadata": {"resourceVersion": "1"}, "spec": "something"},
+            {"metadata": {}, "spec": "something"},
+        ),
+        (
+            {
+                "metadata": {
+                    "resourceVersion": "1",
+                    "uid": "",
+                    "creationTimestamp": "",
+                    "name": "test",
+                },
+                "spec": "something",
+            },
+            {"metadata": {"name": "test"}, "spec": "something"},
+        ),
+    ],
+)
+def test_clean_openshift_metadata(data, expected):
+    assert acct_mgt.moc_openshift.clean_openshift_metadata(data) == expected

--- a/tests/unit/moc_openshift/test_moc_openshift_project.py
+++ b/tests/unit/moc_openshift/test_moc_openshift_project.py
@@ -15,7 +15,8 @@ def test_get_project(moc):
 
 
 def test_project_exists(moc):
-    fake_project = mock.Mock(spec=["to_dict"])
+    fake_project = mock.Mock()
+    fake_project.to_dict.return_value = {}
     moc.client.resources.get.return_value.get.return_value = fake_project
     assert moc.project_exists("fake-project")
 


### PR DESCRIPTION
When we retrieve an object from openshift, it includes internal tracking
metadata such as `resourceVersion` that we don't generally care about, and
can cause problems when submitting updates.

This commit introduces the `clean_openshift_metadata` function to remove
these attributes, and applies that to all resource `get` operations.
