### PR TITLE
add default limits and quotas for NVIDIA GPUs

### DIFF
--- a/k8s/base/limits.json
+++ b/k8s/base/limits.json
@@ -3,11 +3,13 @@
         "type": "Container",
         "default": {
             "cpu": "2",
-            "memory": "1024Mi"
+            "memory": "1024Mi",
+            "nvidia.com/gpu": "0"
         },
         "defaultRequest": {
             "cpu": "1",
-            "memory": "512Mi"
+            "memory": "512Mi",
+            "nvidia.com/gpu": "0"
         }
     }
 ]

--- a/k8s/base/quotas.json
+++ b/k8s/base/quotas.json
@@ -6,6 +6,7 @@
 ":requests.storage":              { "base": 2, "coefficient": 0, "units": "Gi" },
 ":limits.storage":                { "base": 2, "coefficient": 0, "units": "Gi" },
 ":requests.ephemeral-storage":    { "base": 2, "coefficient": 8, "units": "Gi" },
+":requests.nvidia.com/gpu":       { "base": 0, "coefficient": 0 },
 ":limits.ephemeral-storage":      { "base": 2, "coefficient": 8, "units": "Gi" },
 ":persistentvolumeclaims":        { "base": 2, "coefficient": 0 },
 ":replicationcontrollers":        { "base": 2, "coefficient": 0 },


### PR DESCRIPTION
By default a user should get 0 GPUs until they request one via coldfront/openshift-acct-mgt.