### PR TITLE
Changed base manifests to pull image from ghcr

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
               name: onboarding-credentials
           - configMapRef:
               name: onboarding-config
-        image: "localhost:5000/cci-moc/openshift-acct-mgt:latest"
+        image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.3.4"
         imagePullPolicy: Always
         ports:
           - name: http

--- a/k8s/base/image-stream.yaml
+++ b/k8s/base/image-stream.yaml
@@ -1,7 +1,0 @@
-apiVersion: image.openshift.io/v1
-kind: ImageStream
-metadata:
-  name: openshift-acct-mgt
-spec:
-  lookupPolicy:
-    local: true

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
 - namespace.yaml
 - cluster-role-binding.yaml
 - deployment.yaml
-- image-stream.yaml
 - route.yaml
 - service-account.yaml
 - service.yaml


### PR DESCRIPTION
Addressing nerc-project/coldfront-plugin-cloud#91. I changed the image url to point to the public one hosted in ghcr, deleted image-stream.yaml, and made appropriate change to kustomization.yaml