### PR TITLE
Update deployment container image version to `0.3.5`

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
               name: onboarding-credentials
           - configMapRef:
               name: onboarding-config
-        image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.3.4"
+        image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.3.5"
         imagePullPolicy: Always
         ports:
           - name: http


### PR DESCRIPTION
This is blocking https://github.com/nerc-project/coldfront-plugin-cloud/pull/203